### PR TITLE
clash订阅增强

### DIFF
--- a/box/settings.ini
+++ b/box/settings.ini
@@ -64,6 +64,7 @@ uid_list=("/data/adb/box/run/appuid.list")
 # konfigurasi clash
 name_clash_config="config.yaml"
 clash_config="${data_dir}/clash/${name_clash_config}"
+clash_domestic_config="${data_dir}/clash/provide/domestic.yml"
 
 # Mengatur variabel DNS, dokumentasi DNS ada di https://adguard-dns.io/kb/general/dns-providers/.
 # Variabel intervaldns harus dalam format cron. Misalnya "*/10 * * * *" untuk menjalankannya setiap 10 menit.


### PR DESCRIPTION
原clash订阅方式使用的覆盖模式，这会导致每次订阅`config.yml`都需要重新编辑，为了减少不必要的修改，给系统添加[yq](https://github.com/mikefarah/yq)会方便很多，基于yq我也写了个[yq for Magisk](https://github.com/powerAn2020/yq-for-magisk)模块，能够自动下载最新的`yq`版本。如果系统存在yq，则使用yq提取订阅文件中的节点信息到domestic.yml，不存在则继续使用原订阅方式。