### PR TITLE
Using ghproxy to Accelerate Downloads

### DIFF
--- a/.github/workflows/debug.yml
+++ b/.github/workflows/debug.yml
@@ -1,0 +1,31 @@
+name: debug
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Get Version
+        id: get_version
+        run: |
+          echo "version=$(grep -oP 'version=\K[^ ]+' module.prop)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date +%Y%m%d)" >> "$GITHUB_OUTPUT"
+
+      - name: Generate Asset
+        run: |
+          sudo mkdir -p /box_for_root
+          sudo cp -r --parents $(find ./ -type f ! -path './.git/*' ! -name 'CHANGELOG.md' ! -name 'update.json' ! -name 'build.sh' ! -path './.github/*' ! -path './docs/*')  /box_for_root/
+
+      - name: Upload Debug Asset => (box_for_magisk_${{ steps.get_version.outputs.version }}_$(date +%Y%m%d))
+        uses: actions/upload-artifact@v3
+        with:
+          name: "box_for_magisk_${{ steps.get_version.outputs.version }}_${{ steps.get_version.outputs.date }}"
+          path: /box_for_root/

--- a/.github/workflows/del.yml
+++ b/.github/workflows/del.yml
@@ -1,15 +1,15 @@
 name: Delete old workflow runs
-description: This workflow deletes old workflow runs to maintain a clean workflow history.
+
 on:
   workflow_dispatch:
-  
+
 jobs:
   delete_old_runs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete workflow runs
         uses: Mattraks/delete-workflow-runs@v2
-        if: github.ref == 'refs/heads/main'
+        if: github.ref == 'refs/heads/master'
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,12 +16,6 @@ jobs:
       - name: run build.sh
         run: sh build.sh
 
-      - name: Upload Release Asset
-        uses: actions/upload-artifact@v2
-        with:
-          name: box_for_magisk
-          path: box_for_root-v*.zip
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v1
         with:

--- a/box/scripts/box.tool
+++ b/box/scripts/box.tool
@@ -12,6 +12,9 @@ dev=true
 # option to download Singbox kernel beta or release
 singbox_releases=false
 
+# whether use ghproxy to accelerate github download
+use_ghproxy=false
+
 # Check internet connection with mlbox
 check_connection_with_mlbox() {
   now=$(date +"%R")
@@ -105,6 +108,23 @@ update_file() {
   file_bak="${file}.bak"
   if [ -f "${file}" ]; then
     mv "${file}" "${file_bak}" || return 1
+  fi
+  # Enable ghproxy to accelerate download
+  if [[ "$use_ghproxy" == false ]] && ([[ "$update_url" == "https://github.com/"* ]] || [[ "$update_url" == "https://raw.githubusercontent.com/"* ]] || [[ "$update_url" == "https://gist.github.com/"* ]] || [[ "$update_url" == "https://gist.githubusercontent.com/"* ]]); then
+    echo "- It seems that you are downloading from GitHub."
+    echo "- Do you want to use the GitHub proxy service to download?"
+    echo "- [ Vol UP: Yes ]"
+    echo "- [ Vol DOWN: No ]"
+    while true; do
+      getevent -lc 1 2>&1 | grep -q KEY_VOLUMEUP && {
+        use_ghproxy=true
+        break
+      }
+      getevent -lc 1 2>&1 | grep -q KEY_VOLUMEDOWN && break
+    done
+  fi
+  if [[ "$use_ghproxy" == true ]]; then
+    update_url="https://ghproxy.com/${update_url}"
   fi
   request="busybox wget"
   request+=" --no-check-certificate"


### PR DESCRIPTION
I have done the following tasks:

1. Asked whether to use ghproxy to accelerate downloads of GitHub-related files.

2. Separated the `release` and `artifacts` publishing, generating artifacts for each submission with a corresponding timestamp version.

3. There seems to be an issue with `del.yml`, but I did not modify its main body. It may be due to my token.