### PR TITLE
feat: add yacd autostart settings & fix some yq bugs

### DIFF
--- a/.github/workflows/del.yml
+++ b/.github/workflows/del.yml
@@ -14,4 +14,4 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           repository: ${{ github.repository }}
           retain_days: 0
-          keep_minimum_runs: 0
+          keep_minimum_runs: 5

--- a/box/scripts/box.service
+++ b/box/scripts/box.service
@@ -464,6 +464,11 @@ start_box() {
   detected_port
   still_alive
   display_bin_pid
+  # Open the yacd in browser
+  if [ "${bin_name}" = "clash" ] && [ "${display_yacd_on_start}" = "true" ]; then
+    sleep 0.5
+    am start -a android.intent.action.VIEW -d http://127.0.0.1:9090/ui
+  fi
 }
 
 stop_box() {

--- a/box/settings.ini
+++ b/box/settings.ini
@@ -73,6 +73,7 @@ system_packages_file="/data/system/packages.list"
 uid_list=("/data/adb/box/run/appuid.list")
 
 # clash configuration
+display_yacd_on_start="false"
 name_clash_config="config.yaml"
 clash_config="${data_dir}/clash/${name_clash_config}"
 clash_domestic_config="${data_dir}/clash/provide/domestic.yml"


### PR DESCRIPTION
1. Add `display_yacd_on_start` property in `settings.ini`, the default is `false`. If set to true , the browser will open yacd when the service starts.
2. Fix yq download bug. `[ "$yq_command" -eq 0 ]` should be `[ "$yq_command" -eq 1 ]`.
3. Fallback: keep `.subscription`` download file name suffix.
4. `Del.yml` contains 5 workflows.