### PR TITLE
customize.sh: Add 10s timeout for Kernel Download.

### DIFF
--- a/customize.sh
+++ b/customize.sh
@@ -87,8 +87,8 @@ ui_print "- [ Vol DOWN(-): No ]"
 START_TIME=$(date +%s)
 while true ; do
   NOW_TIME=$(date +%s)
-  timeout 1 getevent -lc 1 2>&1 | grep KEY_VOLUME > $TMPDIR/events
-  if [ $(( $NOW_TIME - $START_TIME )) -gt 9 ] ; then
+  timeout 1 getevent -lc 1 2>&1 | grep KEY_VOLUME > "$TMPDIR/events"
+  if [ $(( NOW_TIME - START_TIME )) -gt 9 ] ; then
     ui_print "- No input detected after 10 seconds"
     ui_print "- Downloading Kernel Anyway...."
     /data/adb/box/scripts/box.tool all


### PR DESCRIPTION
some users complaining about broken volume keys.
so here we added 10s timeout for pressing vol-up or vol-down. if time runs out and no input from users, script will download the kernel anyway.