### PR TITLE
BOX_EXTERNAL should be added to PREROUTING chain only once

### DIFF
--- a/box/scripts/box.iptables
+++ b/box/scripts/box.iptables
@@ -383,8 +383,6 @@ start_tproxy() {
       fi
     done
   fi
-  # Append the BOX_EXTERNAL chain to the PREROUTING chain
-  ${iptables} -t mangle -A PREROUTING -j BOX_EXTERNAL
 
   ${iptables} -t mangle -A BOX_EXTERNAL -p tcp -i lo -j TPROXY --on-port "${tproxy_port}" --tproxy-mark "${fwmark}"
   ${iptables} -t mangle -A BOX_EXTERNAL -p udp -i lo -j TPROXY --on-port "${tproxy_port}" --tproxy-mark "${fwmark}"


### PR DESCRIPTION
BOX_EXTERNAL chain is added to PREROUTING chain twice
[https://github.com/taamarin/box_for_magisk/blob/68352db907bdf7ea1f264334dd7dc144ceb2765b/box/scripts/box.iptables#L387](https://github.com/taamarin/box_for_magisk/blob/68352db907bdf7ea1f264334dd7dc144ceb2765b/box/scripts/box.iptables#L387)

and

[https://github.com/taamarin/box_for_magisk/blob/68352db907bdf7ea1f264334dd7dc144ceb2765b/box/scripts/box.iptables#L406](https://github.com/taamarin/box_for_magisk/blob/68352db907bdf7ea1f264334dd7dc144ceb2765b/box/scripts/box.iptables#L406)