### PR TITLE
Modify the bug of obtaining local IPv6 (box.iptables)

### DIFF
--- a/box/scripts/box.iptables
+++ b/box/scripts/box.iptables
@@ -174,7 +174,7 @@ intranet6=(
   fe80::/10
   ff00::/8
 )
-intranet6+=($(ip -6 address | busybox awk '/inet6/ && !/::1/ && !/fe80/ {print $2}'))
+intranet6+=($(ip -6 a | busybox awk '/inet6/ {print $2}' | busybox grep -vE "^fe80|^::1|^fd00"))
 
 forward() {
   ${iptables} $1 FORWARD -o "${tun_device}" -j ACCEPT


### PR DESCRIPTION
具体请见issue: #93 

box.iptables 中 获取本机ipv6地址，并将其加入到intranet6的代码有误。

错误代码如下, 当本机ipv6例如`2001:2de0:b::1241`的时候，会被规则过滤，与目的不符（目的是过滤本地回环地址和内网地址）。
```sh
intranet6+=($(ip -6 address | busybox awk '/inet6/ && !/::1/ && !/fe80/ {print $2}'))
```
代码应修改如下
```sh
intranet6+=($(ip -6 a | busybox awk '/inet6/ {print $2}' | busybox grep -vE "^fe80|^::1|^fd00"))
```
[问题代码](https://github.com/taamarin/box_for_magisk/blob/master/box/scripts/box.iptables#L177)
