### PR TITLE
修复 README 的错误

### DIFF
--- a/docs/index_cn.md
+++ b/docs/index_cn.md
@@ -25,7 +25,7 @@
 
 ```shell
 # 更新选定的内核
-su -c /data/adb/box/scripts/box.tool upcore
+su -c /data/adb/box/scripts/box.tool upkernel
 ```
 
 如果您使用 `clash` 作为你的选定内核，您可能还需要执行如下指令开启控制面板:

--- a/docs/index_en.md
+++ b/docs/index_en.md
@@ -25,7 +25,7 @@ Make sure you are connected to the internet and run the following command to upd
 
 ```shell
 # Update the selected kernel, based on `${bin_name}`.
-su -c /data/adb/box/scripts/box.tool upcore
+su -c /data/adb/box/scripts/box.tool upkernel
 ```
 
 If you are using `clash/sing-box` as the selected kernel, you may also need to run the following command to open the control panel:

--- a/docs/index_id.md
+++ b/docs/index_id.md
@@ -26,7 +26,7 @@ Pastikan Anda terhubung ke internet dan jalankan perintah berikut untuk memperba
 
 ```shell
 # perbarui kernel yang dipilih, sesuai dengan `bin_name`
-su -c /data/adb/box/scripts/box.tool upcore
+su -c /data/adb/box/scripts/box.tool upkernel
 ```
 
 Jika Anda menggunakan `clash/sing-box` sebagai kernel yang dipilih, Anda mungkin juga perlu menjalankan perintah berikut untuk dapat menggunakan panel kontro(dashboard):


### PR DESCRIPTION
某次 Commit 将 upcore 更改为 upkernel 导致此处错误，故更改。