### PR TITLE
Fix dns leak again

### DIFF
--- a/box/scripts/box.iptables
+++ b/box/scripts/box.iptables
@@ -128,8 +128,8 @@ disable_ipv6() {
   # add: block Askes ipv6 completely
   ip -6 rule add unreachable pref "${pref}"
 
-  # add: blocks all outgoing IPv6 traffic using the UDP protocol to port 53, effectively preventing DNS queries over IPv6.
-  $IP6V -A OUTPUT -p udp --destination-port 53 -j DROP
+  # del: blocks all outgoing IPv6 traffic using the UDP protocol to port 53, effectively preventing DNS queries over IPv6.
+  $IP6V -D OUTPUT -p udp --destination-port 53 -j DROP
 } >> /dev/null 2>&1
 
 ipv6_enable() {
@@ -145,8 +145,8 @@ ipv6_enable() {
   # del: block Askes ipv6 completely
   ip -6 rule del unreachable pref "${pref}"
 
-  # del: blocks all outgoing IPv6 traffic using the UDP protocol to port 53, effectively preventing DNS queries over IPv6.
-  $IP6V -D OUTPUT -p udp --destination-port 53 -j DROP
+  # add: blocks all outgoing IPv6 traffic using the UDP protocol to port 53, effectively preventing DNS queries over IPv6.
+  $IP6V -A OUTPUT -p udp --destination-port 53 -j DROP
 } >> /dev/null 2>&1
 
 intranet=(

--- a/box/scripts/box.iptables
+++ b/box/scripts/box.iptables
@@ -127,9 +127,6 @@ disable_ipv6() {
 
   # add: block Askes ipv6 completely
   ip -6 rule add unreachable pref "${pref}"
-
-  # del: blocks all outgoing IPv6 traffic using the UDP protocol to port 53, effectively preventing DNS queries over IPv6.
-  $IP6V -D OUTPUT -p udp --destination-port 53 -j DROP
 } >> /dev/null 2>&1
 
 ipv6_enable() {


### PR DESCRIPTION
Do not need to intercept DNS port when IPv6 is not enabled. but, when IPv6 is enabled, not intercepting the IPv6 DNS port can lead to DNS leak
Android seems to have no way to forward IPv6 DNS port, as long as they are not intercepted, there is definitely a risk of DNS leak