### PR TITLE
box.iptables: improve read build version for iptables wait

### DIFF
--- a/box/scripts/box.iptables
+++ b/box/scripts/box.iptables
@@ -12,14 +12,16 @@ tun_forward="enable"
 clash_dns_forward="enable"
 fake_ip_range=""
 
-va1=$(getprop ro.build.version.release)
-va2="11"
-if [ "$va1" -ge "$va2" ]; then
+# ex: 7.1.1
+buildVersion=$(getprop ro.build.version.release)
+minBuildVersion="11"
+IPV="iptables" # Default
+IP6V="ip6tables" # Default
+# ex: 7.1.1 -> 7
+buildVersionMajor=${buildVersion%%.*}
+if [ "$buildVersionMajor" -ge "$minBuildVersion" ]; then
   IPV="iptables -w 100"
   IP6V="ip6tables -w 100"
-else
-  IPV="iptables"
-  IP6V="ip6tables"
 fi
 
 case "${bin_name}" in


### PR DESCRIPTION
`getprop ro.build.version.release` output can be `5.1.1`. We just need major version `5` to compared with minimum `11`

