### PR TITLE
修正一小处可能无关紧要笔误

### DIFF
--- a/box/settings.ini
+++ b/box/settings.ini
@@ -81,7 +81,7 @@ renew="false"
 update_subscription="false"
 
 # Source subscription URL for Clash configuration
-# if "renew=treu" , will only process the first url"
+# if "renew=true" , will only process the first url"
 subscription_url_clash=("http://127.0.0.1:12345/api/file/clash1.yaml" "http://127.0.0.1:12345/api/file/clash2.yaml")
 
 # Source subscription URL for sing-box configuration


### PR DESCRIPTION
修正“treu”为“true”的拼写错误